### PR TITLE
Idea: Add nullable query parameters

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -43,11 +43,15 @@ router.get(
     sortable({ fields: ['id', 'name'], default: '+id' }),
     query('role', string('none', 'admin'), {
       description: 'If provided will filter users based on this role',
+      required: true
+    }),
+    query('maybeRole', string('none', 'admin'), {
+      description: 'If provided will filter users based on this role',
     }),
     returns(Ok(ArrayOfSchema(UserSchema)))
   ),
   (ctx, next) => {
-    const { offset, limit, sort, role } = ctx.state.params;
+    const { offset, limit, sort, role, maybeRole } = ctx.state.params;
     ctx.state.returns = [];
   }
 );


### PR DESCRIPTION
👋 hey! I've been playing with this today, and really impressed by what's here so far! I'm experimenting with porting a couple Express endpoints (that are current missing runtime _and_ static validations 😬) to Koa + restea.

One thing I noticed was that `query()` always types its resulting `state.params[key]` as the type of the validator, even for optional parameters that could be undefined at runtime. I wanted to add null-safety to these types.

I went ahead and implemented this using function overloads and TypeScript's discriminated unions. The quick version is that when you pass `required: true,` a function overload is used that types the resulting param as `TType`. If you don't pass `required: true`, an overload is used that marks the type as `TType | undefined`.

The downside, as I noted in a comment, is that using function overloads for this involves some type-unsoundness: I couldn't figure out how to type the actual _logic_ inside `query()` for this behavior, so instead the logic only guarantees `TType | undefined` is returned, and the overload type-casts the result. I'm not sure if this is possible to avoid.

The big missing TODO on this is that default values are not properly supported (supplying `default: T` will still result in a param of type `T | undefined` when it should always be `T`). I think this should be an easy additional overload to add, though.

I've updated the example code so you can see the difference in types (`role` is always of type `"admin | "none"`; `maybeRole` is `"admin" | "none" | undefined`). I'll let you know if I run into any issues using this change on my experiment project.